### PR TITLE
Autofac fixes

### DIFF
--- a/src/Containers/MassTransit.AutoFacIntegration/AutofacConsumerFactoryConfigurator.cs
+++ b/src/Containers/MassTransit.AutoFacIntegration/AutofacConsumerFactoryConfigurator.cs
@@ -21,11 +21,11 @@ namespace MassTransit.AutofacIntegration
     public class AutofacConsumerFactoryConfigurator
     {
         readonly SubscriptionBusServiceConfigurator _configurator;
-        readonly IComponentContext _container;
+        readonly ILifetimeScope _scope;
 
-        public AutofacConsumerFactoryConfigurator(SubscriptionBusServiceConfigurator configurator, IComponentContext container)
+        public AutofacConsumerFactoryConfigurator(SubscriptionBusServiceConfigurator configurator, ILifetimeScope scope)
         {
-            _container = container;
+            _scope = scope;
             _configurator = configurator;
         }
 
@@ -38,7 +38,7 @@ namespace MassTransit.AutofacIntegration
         public void Configure<T>()
             where T : class
         {
-            _configurator.Consumer(new AutofacConsumerFactory<T>(_container));
+            _configurator.Consumer(new AutofacConsumerFactory<T>(_scope));
         }
     }
 }

--- a/src/Containers/MassTransit.AutoFacIntegration/AutofacSagaRepositoryFactoryConfigurator.cs
+++ b/src/Containers/MassTransit.AutoFacIntegration/AutofacSagaRepositoryFactoryConfigurator.cs
@@ -22,11 +22,11 @@ namespace MassTransit.AutofacIntegration
 	public class AutofacSagaRepositoryFactoryConfigurator
 	{
 		readonly SubscriptionBusServiceConfigurator _configurator;
-        readonly IComponentContext _container;
+        readonly ILifetimeScope _scope;
 
-        public AutofacSagaRepositoryFactoryConfigurator(SubscriptionBusServiceConfigurator configurator, IComponentContext container)
+        public AutofacSagaRepositoryFactoryConfigurator(SubscriptionBusServiceConfigurator configurator, ILifetimeScope scope)
 		{
-			_container = container;
+            _scope = scope;
 			_configurator = configurator;
 		}
 
@@ -39,7 +39,7 @@ namespace MassTransit.AutofacIntegration
 		public void Configure<T>()
 			where T : class, ISaga
 		{
-			_configurator.Saga(_container.Resolve<ISagaRepository<T>>());
+			_configurator.Saga(_scope.Resolve<ISagaRepository<T>>());
 		}
 	}
 }


### PR DESCRIPTION
I have made the changes I talked about, now passing in a ILifetimeScope instead of the IContainerContext, this enables the consumer factory to create a new child scope and resolve using the child scope. This ensures once the child scope is disposed any resolved handlers are disposed properly.

I notice we only resolve saga repositories as a singleton so did not see the need for anything here. An example autofac module that I use to do my registration is like so:

<pre>
public class ServiceBusModule : Module
{
    protected override void Load(ContainerBuilder builder)
    {
       builder.Register(c =>
                            ServiceBusFactory.New(sbc =>
                        {
                            var scope = c.Resolve<ILifetimeScope>();

                            sbc.UseMsmq();
                            sbc.UseMulticastSubscriptionClient();
                            sbc.VerifyMsmqConfiguration();
                            sbc.ReceiveFrom("msmq://localhost/appkube-service");

                            sbc.UseControlBus();

                            sbc.Subscribe(sbsc => sbsc.LoadFrom(scope));
                        })).SingleInstance();
    }
}
</pre>


I can then register this module with my container and life is good again. I tested the resolution of handlers and can see that the child scope created inside the consumer factory is in fact disposed properly. Would be good also if we can update the documentation with the autofac registration example, I am happy to help out here.

Thanks
Stefan
