### PR TITLE
Marked subscription messages with [Serialization]

### DIFF
--- a/src/MassTransit/Subscriptions/Messages/AddPeerMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/AddPeerMessage.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Subscriptions.Messages
 {
+	using System;
+
+	[Serializable]
 	public class AddPeerMessage : 
 		PeerMessage,
 		AddPeer

--- a/src/MassTransit/Subscriptions/Messages/AddPeerSubscription.cs
+++ b/src/MassTransit/Subscriptions/Messages/AddPeerSubscription.cs
@@ -10,6 +10,8 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
+using System;
+
 namespace MassTransit.Subscriptions.Messages
 {
 	public interface AddPeerSubscription :

--- a/src/MassTransit/Subscriptions/Messages/AddPeerSubscriptionMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/AddPeerSubscriptionMessage.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Subscriptions.Messages
 {
+	using System;
+
+	[Serializable]
 	public class AddPeerSubscriptionMessage :
 		PeerSubscriptionMessage,
 		AddPeerSubscription

--- a/src/MassTransit/Subscriptions/Messages/PeerMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/PeerMessage.cs
@@ -14,6 +14,7 @@ namespace MassTransit.Subscriptions.Messages
 {
 	using System;
 
+	[Serializable]
 	public abstract class PeerMessage
 	{
 		public Guid PeerId { get; set; }

--- a/src/MassTransit/Subscriptions/Messages/PeerSubscriptionMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/PeerSubscriptionMessage.cs
@@ -14,6 +14,7 @@ namespace MassTransit.Subscriptions.Messages
 {
 	using System;
 
+	[Serializable]
 	public abstract class PeerSubscriptionMessage :
 		SubscriptionMessage
 	{

--- a/src/MassTransit/Subscriptions/Messages/RemovePeerMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/RemovePeerMessage.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Subscriptions.Messages
 {
+	using System;
+
+	[Serializable]
 	public class RemovePeerMessage :
 		PeerMessage,
 		RemovePeer

--- a/src/MassTransit/Subscriptions/Messages/RemovePeerSubscriptionMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/RemovePeerSubscriptionMessage.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Subscriptions.Messages
 {
+	using System;
+
+	[Serializable]
 	public class RemovePeerSubscriptionMessage :
 		PeerSubscriptionMessage,
 		RemovePeerSubscription

--- a/src/MassTransit/Subscriptions/Messages/SubscribeToMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/SubscribeToMessage.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Subscriptions.Messages
 {
+	using System;
+
+	[Serializable]
 	public class SubscribeToMessage :
 		SubscriptionMessage,
 		SubscribeTo

--- a/src/MassTransit/Subscriptions/Messages/SubscriptionAddedMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/SubscriptionAddedMessage.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Subscriptions.Messages
 {
+	using System;
+
+	[Serializable]
 	public class SubscriptionAddedMessage :
 		SubscriptionMessage,
 		SubscriptionAdded

--- a/src/MassTransit/Subscriptions/Messages/SubscriptionRemovedMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/SubscriptionRemovedMessage.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Subscriptions.Messages
 {
+	using System;
+
+	[Serializable]
 	public class SubscriptionRemovedMessage :
 		SubscriptionMessage,
 		SubscriptionRemoved

--- a/src/MassTransit/Subscriptions/Messages/UnsubscribeFromMessage.cs
+++ b/src/MassTransit/Subscriptions/Messages/UnsubscribeFromMessage.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace MassTransit.Subscriptions.Messages
 {
+	using System;
+
+	[Serializable]
 	public class UnsubscribeFromMessage :
 		SubscriptionMessage,
 		UnsubscribeFrom


### PR DESCRIPTION
Hi,
I had an exception: "AddPeerMessage is not marked as Serializable" when configuring the bus with `.UseBinarySerialization()` instead of default (Json) one.

Seems I simply fixed that; it works for me
