### PR TITLE
Fix in NHibernateSagaRepository`1

### DIFF
--- a/src/Persistence/MassTransit.NHibernateIntegration/Saga/NHibernateSagaRepository.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration/Saga/NHibernateSagaRepository.cs
@@ -130,7 +130,8 @@ namespace MassTransit.NHibernateIntegration.Saga
                     }
                 }
 
-                transaction.Commit();
+                if (transaction.IsActive)
+                  transaction.Commit();
             }
         }
 


### PR DESCRIPTION
I noticed that in case of an exception inside a saga, the repository still tries to commit a transaction that has already been rolled back.
