### PR TITLE
NLog Exception Logging Fix

### DIFF
--- a/src/Loggers/MassTransit.NLogIntegration/Logging/NLogLog.cs
+++ b/src/Loggers/MassTransit.NLogIntegration/Logging/NLogLog.cs
@@ -109,7 +109,7 @@ namespace MassTransit.NLogIntegration.Logging
 
         public void Info(object obj, Exception exception)
         {
-            _log.Log(NLog.LogLevel.Info, obj == null ? "" : obj.ToString(), exception);
+            _log.LogException(NLog.LogLevel.Info, obj == null ? "" : obj.ToString(), exception);
         }
 
         public void Info(LogOutputProvider messageProvider)
@@ -124,7 +124,7 @@ namespace MassTransit.NLogIntegration.Logging
 
         public void Warn(object obj, Exception exception)
         {
-            _log.Log(NLog.LogLevel.Warn, obj == null ? "" : obj.ToString(), exception);
+            _log.LogException(NLog.LogLevel.Warn, obj == null ? "" : obj.ToString(), exception);
         }
 
         public void Warn(LogOutputProvider messageProvider)
@@ -139,7 +139,7 @@ namespace MassTransit.NLogIntegration.Logging
 
         public void Error(object obj, Exception exception)
         {
-            _log.Log(NLog.LogLevel.Error, obj == null ? "" : obj.ToString(), exception);
+            _log.LogException(NLog.LogLevel.Error, obj == null ? "" : obj.ToString(), exception);
         }
 
         public void Error(LogOutputProvider messageProvider)
@@ -154,7 +154,7 @@ namespace MassTransit.NLogIntegration.Logging
 
         public void Fatal(object obj, Exception exception)
         {
-            _log.Log(NLog.LogLevel.Fatal, obj == null ? "" : obj.ToString(), exception);
+            _log.LogException(NLog.LogLevel.Fatal, obj == null ? "" : obj.ToString(), exception);
         }
 
         public void Fatal(LogOutputProvider messageProvider)


### PR DESCRIPTION
The NLog methods for logging exceptions were calling the wrong Log method. The exception was being used as a string format argument to the message.
