### PR TITLE
Allow endpoint configuration of 'Recoverable' property for Msmq messages

### DIFF
--- a/src/Transports/MassTransit.Transports.Msmq/IMsmqEndpointAddress.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/IMsmqEndpointAddress.cs
@@ -13,6 +13,7 @@
 namespace MassTransit.Transports.Msmq
 {
     using System;
+    using System.Messaging;
 
     public interface IMsmqEndpointAddress :
 		IEndpointAddress
@@ -41,5 +42,10 @@ namespace MassTransit.Transports.Msmq
 		/// The format name used to send messages (may be different if multicast MSMQ is used)
 		/// </summary>
 		string OutboundFormatName { get; }
+
+        /// <summary>
+        /// For non-transactional queues only, determines how to set <see cref="Message.Recoverable"/> property on messages destined for this queue.
+        /// </summary>
+        bool IsRecoverable { get; }
 	}
 }

--- a/src/Transports/MassTransit.Transports.Msmq/MsmqEndpointAddress.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/MsmqEndpointAddress.cs
@@ -14,17 +14,18 @@ namespace MassTransit.Transports.Msmq
 {
 	using System;
 	using System.Messaging;
+	using Util;
 
-	public class MsmqEndpointAddress :
+    public class MsmqEndpointAddress :
 		EndpointAddress,
 		IMsmqEndpointAddress
 	{
-		public MsmqEndpointAddress(Uri uri)
-            : this(uri, false)
+        public MsmqEndpointAddress(Uri uri)
+            : this(uri, false, true)
 		{
 		}
 
-	    public MsmqEndpointAddress(Uri uri, bool defaultTransactional)
+	    public MsmqEndpointAddress(Uri uri, bool defaultTransactional, bool defaultRecoverable)
 			: base(uri)
 		{
 			PublicQueuesNotAllowed();
@@ -36,6 +37,8 @@ namespace MassTransit.Transports.Msmq
 			OutboundFormatName = uri.GetOutboundFormatName();
 
 			IsTransactional = CheckForTransactionalHint(uri, defaultTransactional);
+
+	        IsRecoverable = CheckForRecoverableHint(uri, defaultRecoverable);
 
 			MulticastAddress = uri.GetMulticastAddress();
 			if(MulticastAddress != null)
@@ -58,6 +61,8 @@ namespace MassTransit.Transports.Msmq
 	    public Uri InboundUri { get; private set; }
 
 	    public string OutboundFormatName { get; private set; }
+
+	    public bool IsRecoverable { get; private set; }
 
 	    public string LocalName { get; private set; }
 
@@ -105,11 +110,16 @@ namespace MassTransit.Transports.Msmq
 
 		private Uri SetUriHostToLocalMachineName()
 		{
-			string query = "?tx=" + IsTransactional.ToString().ToLowerInvariant();
+		    string query = String.Format("?tx={0}&recoverable={1}", IsTransactional, IsRecoverable);
 
 			var builder = new UriBuilder(Uri.Scheme, LocalMachineName, Uri.Port, Uri.AbsolutePath, query);
-
+            
 			return builder.Uri;
 		}
+
+        protected static bool CheckForRecoverableHint(Uri uri, bool defaultRecoverable)
+        {
+            return uri.Query.GetValueFromQueryString("recoverable", defaultRecoverable);
+        }
 	}
 }

--- a/src/Transports/MassTransit.Transports.Msmq/MsmqTransportFactory.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/MsmqTransportFactory.cs
@@ -20,6 +20,8 @@ namespace MassTransit.Transports.Msmq
         ITransportFactory
     {
         IMessageNameFormatter _messageNameFormatter;
+        
+        bool defaultRecoverable = true;
 
         public MsmqTransportFactory()
         {
@@ -35,7 +37,7 @@ namespace MassTransit.Transports.Msmq
         {
             try
             {
-                var msmqEndpointAddress = new MsmqEndpointAddress(settings.Address.Uri, settings.Transactional);
+                var msmqEndpointAddress = new MsmqEndpointAddress(settings.Address.Uri, settings.Transactional, defaultRecoverable);
                 TransportSettings msmqSettings = GetTransportSettings(settings, msmqEndpointAddress);
 
                 IInboundTransport inboundTransport = BuildInbound(settings);
@@ -53,7 +55,7 @@ namespace MassTransit.Transports.Msmq
         {
             try
             {
-                var msmqEndpointAddress = new MsmqEndpointAddress(settings.Address.Uri, settings.Transactional);
+                var msmqEndpointAddress = new MsmqEndpointAddress(settings.Address.Uri, settings.Transactional, defaultRecoverable);
                 TransportSettings msmqSettings = GetTransportSettings(settings, msmqEndpointAddress);
 
                 IMsmqEndpointAddress transportAddress = msmqSettings.MsmqAddress();
@@ -84,7 +86,7 @@ namespace MassTransit.Transports.Msmq
         {
             try
             {
-                var msmqEndpointAddress = new MsmqEndpointAddress(settings.Address.Uri, settings.Transactional);
+                var msmqEndpointAddress = new MsmqEndpointAddress(settings.Address.Uri, settings.Transactional, defaultRecoverable);
                 TransportSettings msmqSettings = GetTransportSettings(settings, msmqEndpointAddress);
 
                 IMsmqEndpointAddress transportAddress = msmqSettings.MsmqAddress();

--- a/src/Transports/MassTransit.Transports.Msmq/MsmqUriExtensions.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/MsmqUriExtensions.cs
@@ -58,14 +58,13 @@ namespace MassTransit.Transports.Msmq
 
             return uri.Host;
         }
-
+      
         public static IMsmqEndpointAddress GetQueueAddress(this Uri uri)
         {
             string hostName = GetMsmqHostName(uri);
 
             return new MsmqEndpointAddress(new Uri(new UriBuilder("msmq", hostName).Uri, uri.AbsolutePath));
         }	
-
 
         public static string GetOutboundFormatName(this Uri uri)
         {

--- a/src/Transports/MassTransit.Transports.Msmq/OutboundMsmqTransport.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/OutboundMsmqTransport.cs
@@ -45,7 +45,7 @@ namespace MassTransit.Transports.Msmq
                 if (!string.IsNullOrEmpty(context.MessageType))
                     message.Label = context.MessageType.Length > 250 ? context.MessageType.Substring(0, 250) : context.MessageType;
 
-                message.Recoverable = true;
+                message.Recoverable = _address.IsRecoverable;
 
                 if (context.ExpirationTime.HasValue)
                 {


### PR DESCRIPTION
Additional detail in discussion group:  https://groups.google.com/forum/?fromgroups=#!topic/masstransit-discuss/Akd6AGIG-OI

OutboundMsmqTransport previously hardcoded Message.Recoverable = true.
Recoverable messages have to be written to disk and therefore limit message throughput.

Add boolean URI parameter 'recoverable' to msmq endpoint addresses.
This property is used by OutboundMsmqTransport to set the Message.Recoverable
property on the outgoing message.  If 'recoverable' parameter is not specified,
messages will default to Recoverable=True (the previous default behavior).
