### PR TITLE
Removed all unnecessary finalizers and GC.SuppressFinalize calls

### DIFF
--- a/src/MassTransit.Tests/Distributor/ServiceInstance.cs
+++ b/src/MassTransit.Tests/Distributor/ServiceInstance.cs
@@ -38,7 +38,6 @@ namespace MassTransit.Tests.Distributor
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		protected virtual void Dispose(bool disposing)
@@ -49,11 +48,6 @@ namespace MassTransit.Tests.Distributor
 			DataBus = null;
 
 			_disposed = true;
-		}
-
-		~ServiceInstance()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Distributor/Distributor.cs
+++ b/src/MassTransit/Distributor/Distributor.cs
@@ -87,7 +87,6 @@ namespace MassTransit.Distributor
 //        public void Dispose()
 //        {
 //            Dispose(true);
-//            GC.SuppressFinalize(this);
 //        }
 //
 //        public void Start(IServiceBus bus)
@@ -113,11 +112,6 @@ namespace MassTransit.Distributor
 //                _workers.Clear();
 //
 //            _unsubscribeAction();
-//        }
-//
-//        ~Distributor()
-//        {
-//            Dispose(false);
 //        }
 //
 //        void Dispose(bool disposing)

--- a/src/MassTransit/Distributor/DistributorBusService.cs
+++ b/src/MassTransit/Distributor/DistributorBusService.cs
@@ -44,7 +44,6 @@ namespace MassTransit.Distributor
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Start(IServiceBus bus)
@@ -115,11 +114,6 @@ namespace MassTransit.Distributor
         {
             _subscriptions.Each(x => x.OnStop());
             _subscriptions.Clear();
-        }
-
-        ~DistributorBusService()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Distributor/Worker.cs
+++ b/src/MassTransit/Distributor/Worker.cs
@@ -131,12 +131,6 @@ namespace MassTransit.Distributor
 //        public void Dispose()
 //        {
 //            Dispose(true);
-//            GC.SuppressFinalize(this);
-//        }
-//
-//        ~Worker()
-//        {
-//            Dispose(false);
 //        }
 //
 //        void Dispose(bool disposing)

--- a/src/MassTransit/Distributor/WorkerBusService.cs
+++ b/src/MassTransit/Distributor/WorkerBusService.cs
@@ -56,7 +56,6 @@ namespace MassTransit.Distributor
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Start(IServiceBus bus)
@@ -152,11 +151,6 @@ namespace MassTransit.Distributor
         {
             _subscriptions.Each(x => x.OnStop());
             _subscriptions.Clear();
-        }
-
-        ~WorkerBusService()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Distributor/WorkerPendingMessageTracker.cs
+++ b/src/MassTransit/Distributor/WorkerPendingMessageTracker.cs
@@ -41,7 +41,6 @@ namespace MassTransit.Distributor
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public void Consumed(T item)
@@ -69,11 +68,6 @@ namespace MassTransit.Distributor
 			}
 
 			_disposed = true;
-		}
-
-		~WorkerPendingMessageTracker()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Monitoring/InstancePerformanceCounter.cs
+++ b/src/MassTransit/Monitoring/InstancePerformanceCounter.cs
@@ -47,7 +47,6 @@ namespace MassTransit.Monitoring
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Close()
@@ -94,11 +93,6 @@ namespace MassTransit.Monitoring
             }
 
             _disposed = true;
-        }
-
-        ~InstancePerformanceCounter()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Monitoring/ServiceBusInstancePerformanceCounters.cs
+++ b/src/MassTransit/Monitoring/ServiceBusInstancePerformanceCounters.cs
@@ -64,7 +64,6 @@ namespace MassTransit.Monitoring
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Close()
@@ -166,11 +165,6 @@ namespace MassTransit.Monitoring
             }
 
             _disposed = true;
-        }
-
-        ~ServiceBusInstancePerformanceCounters()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/ServiceBus.cs
+++ b/src/MassTransit/ServiceBus.cs
@@ -147,7 +147,6 @@ namespace MassTransit
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Publish<T>(T message)

--- a/src/MassTransit/ServiceContainer.cs
+++ b/src/MassTransit/ServiceContainer.cs
@@ -112,7 +112,6 @@ namespace MassTransit
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)
@@ -127,11 +126,6 @@ namespace MassTransit
                 }
             }
             _disposed = true;
-        }
-
-        ~ServiceContainer()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Services/HealthMonitoring/HealthClient.cs
+++ b/src/MassTransit/Services/HealthMonitoring/HealthClient.cs
@@ -78,7 +78,6 @@ namespace MassTransit.Services.HealthMonitoring
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Start(IServiceBus bus)
@@ -124,11 +123,6 @@ namespace MassTransit.Services.HealthMonitoring
                 context =>
                 _log.Info(
                     "No routing entry found for the HeartBeat message. Are you sure the HealthMonitor is setup correctly?"));
-        }
-
-        ~HealthClient()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Services/Subscriptions/Server/SubscriptionService.cs
+++ b/src/MassTransit/Services/Subscriptions/Server/SubscriptionService.cs
@@ -84,7 +84,6 @@ namespace MassTransit.Services.Subscriptions.Server
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Start()
@@ -198,11 +197,6 @@ namespace MassTransit.Services.Subscriptions.Server
             var response = new SubscriptionRefresh(subscriptions);
 
             endpoint.Send(response, x => x.SetSourceAddress(_bus.Endpoint.Address.Uri));
-        }
-
-        ~SubscriptionService()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Services/Timeout/TimeoutService.cs
+++ b/src/MassTransit/Services/Timeout/TimeoutService.cs
@@ -48,12 +48,6 @@ namespace MassTransit.Services.Timeout
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-
-		~TimeoutService()
-		{
-			Dispose(false);
 		}
 
 		void Dispose(bool disposing)

--- a/src/MassTransit/Subscriptions/Coordinator/BusSubscriptionRepository.cs
+++ b/src/MassTransit/Subscriptions/Coordinator/BusSubscriptionRepository.cs
@@ -58,7 +58,6 @@ namespace MassTransit.Subscriptions.Coordinator
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Load(SubscriptionRouter router)
@@ -138,11 +137,6 @@ namespace MassTransit.Subscriptions.Coordinator
             {
                 _log.Error("Failed to remove persistent subscription", ex);
             }
-        }
-
-        ~BusSubscriptionRepository()
-        {
-            Dispose(false);
         }
 
         void Dispose(bool disposing)

--- a/src/MassTransit/Subscriptions/Coordinator/InMemorySubscriptionStorage.cs
+++ b/src/MassTransit/Subscriptions/Coordinator/InMemorySubscriptionStorage.cs
@@ -38,7 +38,6 @@ namespace MassTransit.Subscriptions.Coordinator
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Add(PersistentSubscription subscription)
@@ -87,11 +86,6 @@ namespace MassTransit.Subscriptions.Coordinator
             }
 
             _disposed = true;
-        }
-
-        ~InMemorySubscriptionStorage()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Subscriptions/Coordinator/SubscriptionRouterService.cs
+++ b/src/MassTransit/Subscriptions/Coordinator/SubscriptionRouterService.cs
@@ -76,7 +76,6 @@ namespace MassTransit.Subscriptions.Coordinator
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Start(IServiceBus bus)
@@ -194,11 +193,6 @@ namespace MassTransit.Subscriptions.Coordinator
 
         class ExitImpl : Exit
         {
-        }
-
-        ~SubscriptionRouterService()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Subscriptions/DisposableUnsubscribeAction.cs
+++ b/src/MassTransit/Subscriptions/DisposableUnsubscribeAction.cs
@@ -28,7 +28,6 @@ namespace MassTransit.Subscriptions
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public void Add(UnsubscribeAction action)
@@ -44,11 +43,6 @@ namespace MassTransit.Subscriptions
 				_action();
 			}
 			_disposed = true;
-		}
-
-		~DisposableUnsubscribeAction()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Subscriptions/SubscriptionBusService.cs
+++ b/src/MassTransit/Subscriptions/SubscriptionBusService.cs
@@ -47,7 +47,6 @@ namespace MassTransit.Subscriptions
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public void Start(IServiceBus bus)
@@ -93,11 +92,6 @@ namespace MassTransit.Subscriptions
 		{
 			_subscriptions.Each(x => x.OnStop());
 			_subscriptions.Clear();
-		}
-
-		~SubscriptionBusService()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Testing/Instances/ConsumerTestInstance.cs
+++ b/src/MassTransit/Testing/Instances/ConsumerTestInstance.cs
@@ -58,10 +58,5 @@ namespace MassTransit.Testing.Instances
 
 			_disposed = true;
 		}
-
-		~ConsumerTestInstance()
-		{
-			Dispose(false);
-		}
 	}
 }

--- a/src/MassTransit/Testing/Instances/HandlerTestInstance.cs
+++ b/src/MassTransit/Testing/Instances/HandlerTestInstance.cs
@@ -59,10 +59,5 @@ namespace MassTransit.Testing.Instances
 
 			_disposed = true;
 		}
-
-		~HandlerTestInstance()
-		{
-			Dispose(false);
-		}
 	}
 }

--- a/src/MassTransit/Testing/Instances/SagaTestInstance.cs
+++ b/src/MassTransit/Testing/Instances/SagaTestInstance.cs
@@ -59,10 +59,5 @@ namespace MassTransit.Testing.Instances
 
 			_disposed = true;
 		}
-
-		~SagaTestInstance()
-		{
-			Dispose(false);
-		}
 	}
 }

--- a/src/MassTransit/Testing/Instances/TestInstance.cs
+++ b/src/MassTransit/Testing/Instances/TestInstance.cs
@@ -59,7 +59,6 @@ namespace MassTransit.Testing.Instances
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		protected virtual void Dispose(bool disposing)
@@ -76,11 +75,6 @@ namespace MassTransit.Testing.Instances
 		protected void ExecuteTestActions()
 		{
 			_actions.Each(x => x.Act(_scenario));
-		}
-
-		~TestInstance()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Testing/Scenarios/BusTestScenarioImpl.cs
+++ b/src/MassTransit/Testing/Scenarios/BusTestScenarioImpl.cs
@@ -69,10 +69,5 @@ namespace MassTransit.Testing.Scenarios
 
 			_disposed = true;
 		}
-
-		~BusTestScenarioImpl()
-		{
-			Dispose(false);
-		}
 	}
 }

--- a/src/MassTransit/Testing/Scenarios/EndpointTestScenarioImpl.cs
+++ b/src/MassTransit/Testing/Scenarios/EndpointTestScenarioImpl.cs
@@ -92,7 +92,6 @@ namespace MassTransit.Testing.Scenarios
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public void AddEndpoint(EndpointTestDecorator endpoint)
@@ -168,11 +167,6 @@ namespace MassTransit.Testing.Scenarios
 		    {
 		        _endpointCache.Inspect(probe);
 		    }
-		}
-
-		~EndpointTestScenarioImpl()
-		{
-			Dispose(false);
 		}
 
 		public virtual IServiceBus GetDecoratedBus(IServiceBus bus)

--- a/src/MassTransit/Testing/Scenarios/LocalRemoteTestScenarioImpl.cs
+++ b/src/MassTransit/Testing/Scenarios/LocalRemoteTestScenarioImpl.cs
@@ -77,11 +77,6 @@ namespace MassTransit.Testing.Scenarios
 			_disposed = true;
 		}
 
-		~LocalRemoteTestScenarioImpl()
-		{
-			Dispose(false);
-		}
-
 		public override IServiceBus GetDecoratedBus(IServiceBus bus)
 		{
 			if (bus == _realLocalBus)

--- a/src/MassTransit/Testing/Subjects/ConsumerTestSubjectImpl.cs
+++ b/src/MassTransit/Testing/Subjects/ConsumerTestSubjectImpl.cs
@@ -41,7 +41,6 @@ namespace MassTransit.Testing.Subjects
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public void Prepare(TScenario scenario)
@@ -66,11 +65,6 @@ namespace MassTransit.Testing.Subjects
 			}
 
 			_disposed = true;
-		}
-
-		~ConsumerTestSubjectImpl()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Testing/Subjects/HandlerTestSubjectImpl.cs
+++ b/src/MassTransit/Testing/Subjects/HandlerTestSubjectImpl.cs
@@ -42,7 +42,6 @@ namespace MassTransit.Testing.Subjects
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public void Prepare(TScenario scenario)
@@ -89,11 +88,6 @@ namespace MassTransit.Testing.Subjects
 			{
 				_received.Add(received);
 			}
-		}
-
-		~HandlerTestSubjectImpl()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Testing/Subjects/SagaTestSubjectImpl.cs
+++ b/src/MassTransit/Testing/Subjects/SagaTestSubjectImpl.cs
@@ -53,7 +53,6 @@ namespace MassTransit.Testing.Subjects
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public IEnumerator<SagaInstance<TSaga>> GetEnumerator()
@@ -103,11 +102,6 @@ namespace MassTransit.Testing.Subjects
 			}
 
 			_disposed = true;
-		}
-
-		~SagaTestSubjectImpl()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Threading/ThreadPoolConsumerPool.cs
+++ b/src/MassTransit/Threading/ThreadPoolConsumerPool.cs
@@ -123,7 +123,6 @@ namespace MassTransit.Threading
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		void Dispose(bool disposing)
@@ -194,11 +193,6 @@ namespace MassTransit.Threading
 					ReceiverCount = _receiverCount,
 					ConsumerCount = _consumerCount,
 				});
-		}
-
-		~ThreadPoolConsumerPool()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Transports/ConnectionHandlerImpl.cs
+++ b/src/MassTransit/Transports/ConnectionHandlerImpl.cs
@@ -79,7 +79,6 @@ namespace MassTransit.Transports
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Use(Action<T> callback)
@@ -163,11 +162,6 @@ namespace MassTransit.Transports
             }
 
             _disposed = true;
-        }
-
-        ~ConnectionHandlerImpl()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Transports/Endpoint.cs
+++ b/src/MassTransit/Transports/Endpoint.cs
@@ -206,7 +206,6 @@ namespace MassTransit.Transports
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Receive(Func<IReceiveContext, Action<IReceiveContext>> receiver, TimeSpan timeout)
@@ -387,11 +386,6 @@ namespace MassTransit.Transports
             _transport.Send(moveContext);
 
             Address.LogReQueued(_transport.Address, context.MessageId, "");
-        }
-
-        ~Endpoint()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Transports/Loopback/LoopbackMessage.cs
+++ b/src/MassTransit/Transports/Loopback/LoopbackMessage.cs
@@ -45,7 +45,6 @@ namespace MassTransit.Transports.Loopback
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         void Dispose(bool disposing)
@@ -57,11 +56,6 @@ namespace MassTransit.Transports.Loopback
             }
 
             _disposed = true;
-        }
-
-        ~LoopbackMessage()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Transports/Loopback/LoopbackTransport.cs
+++ b/src/MassTransit/Transports/Loopback/LoopbackTransport.cs
@@ -215,7 +215,6 @@ namespace MassTransit.Transports
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         void GuardAgainstDisposed()
@@ -248,11 +247,6 @@ namespace MassTransit.Transports
             }
 
             _disposed = true;
-        }
-
-        ~LoopbackTransport()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/MassTransit/Transports/Transport.cs
+++ b/src/MassTransit/Transports/Transport.cs
@@ -35,7 +35,6 @@ namespace MassTransit.Transports
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public IEndpointAddress Address
@@ -100,11 +99,6 @@ namespace MassTransit.Transports
 			}
 
 			_disposed = true;
-		}
-
-		~Transport()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/MassTransit/Util/RegistrationList.cs
+++ b/src/MassTransit/Util/RegistrationList.cs
@@ -29,7 +29,6 @@ namespace MassTransit.Util
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public UnregisterAction Register(T item)
@@ -60,11 +59,6 @@ namespace MassTransit.Util
 
 			_items = null;
 			_disposed = true;
-		}
-
-		~RegistrationList()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/Persistence/MassTransit.NHibernateIntegration.Tests/SqlLiteSessionFactoryProvider.cs
+++ b/src/Persistence/MassTransit.NHibernateIntegration.Tests/SqlLiteSessionFactoryProvider.cs
@@ -48,12 +48,6 @@ namespace MassTransit.NHibernateIntegration.Tests
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        ~SqlLiteSessionFactoryProvider()
-        {
-            Dispose(false);
         }
 
         void Dispose(bool disposing)

--- a/src/Tools/BusDriver/TransportCache.cs
+++ b/src/Tools/BusDriver/TransportCache.cs
@@ -35,7 +35,6 @@ namespace BusDriver
 		public void Dispose()
 		{
 			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		public IDuplexTransport GetTransport(Uri uri)
@@ -86,11 +85,6 @@ namespace BusDriver
 			}
 
 			_disposed = true;
-		}
-
-		~TransportCache()
-		{
-			Dispose(false);
 		}
 	}
 }

--- a/src/Transports/MassTransit.Transports.Msmq/InboundMsmqTransport.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/InboundMsmqTransport.cs
@@ -47,7 +47,6 @@ namespace MassTransit.Transports.Msmq
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         protected void EnumerateQueue(Func<IReceiveContext, Action<IReceiveContext>> receiver, TimeSpan timeout)
@@ -181,11 +180,6 @@ namespace MassTransit.Transports.Msmq
             }
 
             _disposed = true;
-        }
-
-        ~InboundMsmqTransport()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/Transports/MassTransit.Transports.Msmq/MessageQueueConnection.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/MessageQueueConnection.cs
@@ -72,7 +72,6 @@ namespace MassTransit.Transports.Msmq
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Disconnect()
@@ -131,11 +130,6 @@ namespace MassTransit.Transports.Msmq
             }
 
             _disposed = true;
-        }
-
-        ~MessageQueueConnection()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/Transports/MassTransit.Transports.Msmq/OutboundMsmqTransport.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/OutboundMsmqTransport.cs
@@ -82,7 +82,6 @@ namespace MassTransit.Transports.Msmq
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         protected virtual void SendMessage(MessageQueue queue, Message message)
@@ -139,11 +138,6 @@ namespace MassTransit.Transports.Msmq
                 default:
                     throw new InvalidConnectionException(_address.Uri, "There was a problem communicating with the message queue", ex);
             }
-        }
-
-        ~OutboundMsmqTransport()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/Transports/MassTransit.Transports.RabbitMq/InboundRabbitMqTransport.cs
+++ b/src/Transports/MassTransit.Transports.RabbitMq/InboundRabbitMqTransport.cs
@@ -126,7 +126,6 @@ namespace MassTransit.Transports.RabbitMq
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public IEnumerable<Type> BindExchangesForPublisher(Type messageType, IMessageNameFormatter messageNameFormatter)
@@ -214,11 +213,6 @@ namespace MassTransit.Transports.RabbitMq
             }
 
             _disposed = true;
-        }
-
-        ~InboundRabbitMqTransport()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/Transports/MassTransit.Transports.RabbitMq/Management/RabbitMQEndpointManagement.cs
+++ b/src/Transports/MassTransit.Transports.RabbitMq/Management/RabbitMQEndpointManagement.cs
@@ -105,7 +105,6 @@ namespace MassTransit.Transports.RabbitMq.Management
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         void Dispose(bool disposing)
@@ -127,11 +126,6 @@ namespace MassTransit.Transports.RabbitMq.Management
             }
 
             _disposed = true;
-        }
-
-        ~RabbitMqEndpointManagement()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/Transports/MassTransit.Transports.RabbitMq/RabbitMqConnection.cs
+++ b/src/Transports/MassTransit.Transports.RabbitMq/RabbitMqConnection.cs
@@ -38,7 +38,6 @@ namespace MassTransit.Transports.RabbitMq
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         public void Connect()


### PR DESCRIPTION
The dispose/finalize pattern this code base is using is incorrect. Check out this [link](http://stackoverflow.com/questions/574019/calling-null-on-a-class-vs-dispose/574659#574659) on why they are unnecessary.

The only occurance I didn't remove was from MassTransit.TestFramework.Future. It also appears to be superfluous. But because it does not implement IDisposable and it's a test helper. I decided to leave it alone.
