### PR TITLE
Don't allow recoverable msmq address if it is not transactional

### DIFF
--- a/src/Transports/MassTransit.Transports.Msmq/MsmqEndpointAddress.cs
+++ b/src/Transports/MassTransit.Transports.Msmq/MsmqEndpointAddress.cs
@@ -38,7 +38,7 @@ namespace MassTransit.Transports.Msmq
 
 			IsTransactional = CheckForTransactionalHint(uri, defaultTransactional);
 
-	        IsRecoverable = CheckForRecoverableHint(uri, defaultRecoverable);
+	        IsRecoverable = IsTransactional && CheckForRecoverableHint(uri, defaultRecoverable);
 
 			MulticastAddress = uri.GetMulticastAddress();
 			if(MulticastAddress != null)


### PR DESCRIPTION
Related to previous commit f0c8e2bb34, Msmq Endpoints only support
Recoverable messages if they are Transactional.

Change logic in MsmqEndpointAddress to force Recoverable false if
Transactional is false.

Without this change, msmq addresses that are not transactional (default behavior) are getting set up with Recoverable=true.  This causes queuing operations to fail.
