### PR TITLE
Json serializer does not serialize a string to a string when given a DateTime string

### DIFF
--- a/src/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
+++ b/src/MassTransit.Tests/Serialization/JsonSerialization_Specs.cs
@@ -170,6 +170,7 @@ namespace MassTransit.Tests.Serialization
                 // DateTimes are properly serialized / deserialized
                 // however, string properties containing a date-string are somehow
                 // converted to a Datetime somewhere in deserialization
+                // fixed by adding DateParseHandling = DateParseHandling.None to serializer settings
                 message.DateTimeProperty.ShouldEqual(new DateTime(2014, 03, 05, 01, 53, 04, 193),"Round ripping DateTimeProperty failed");
                 message.DateTimeStringProperty.ShouldEqual("2014-03-05T01:53:04.193","Roundtripping DateTimeStringProperty failed");
                 message.Dictionary["string-datetime-property"].ShouldEqual("2014-03-05T01:53:04.193","Roundtripping datetimestring in dictionary failed");

--- a/src/MassTransit/Serialization/JsonMessageSerializer.cs
+++ b/src/MassTransit/Serialization/JsonMessageSerializer.cs
@@ -41,6 +41,7 @@ namespace MassTransit.Serialization
                         ObjectCreationHandling = ObjectCreationHandling.Auto,
                         ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
                         ContractResolver = new JsonContractResolver(),
+                        DateParseHandling = DateParseHandling.None,
                         Converters = new List<JsonConverter>(new JsonConverter[]
                             {
                                 new ByteArrayConverter(), 
@@ -56,6 +57,7 @@ namespace MassTransit.Serialization
                         ObjectCreationHandling = ObjectCreationHandling.Auto,
                         ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
                         ContractResolver = new JsonContractResolver(),
+                        DateParseHandling = DateParseHandling.None,
                         Converters = new List<JsonConverter>(new JsonConverter[]
                             {
                                 new ByteArrayConverter(), 


### PR DESCRIPTION
The Newtonsoft Json does some weird things when given a string property containing a "possible" DateTime.

for example, given the message below

``` c#
_message = new TestMessage
                {
                    Name = "Joe",
                    Details = new List<TestMessageDetail>
                        {
                            new TestMessageDetail {Item = "A", Value = 27.5d},
                            new TestMessageDetail {Item = "B", Value = 13.5d},
                        },
                    DateTimeProperty = new DateTime(2014,03,05,01,53,04,193),
                    DateTimeStringProperty = "2014-03-05T01:53:04.193",
                    Dictionary = new Dictionary<string, string>()
                    {
                        {"string-datetime-property","2014-03-05T01:53:04.193"}
                    }
                };
```

Default, the newtonsoft serializer deserializes the DateTimeStringProperty into a DateTime, when it is actually a string:

``` c#
 using (var jsonReader = new JTokenReader(result.Message as JToken))
            {
                var message = (TestMessage)_serializer.Deserialize(jsonReader, typeof(TestMessage));

                // DateTimes are properly serialized / deserialized
                // however, string properties containing a date-string are somehow
                // converted to a Datetime somewhere in deserialization
                // fixed by adding DateParseHandling = DateParseHandling.None to serializer settings

                // works OK using default settings
                message.DateTimeProperty.ShouldEqual(new DateTime(2014, 03, 05, 01, 53, 04, 193),"Round ripping DateTimeProperty failed");

                // NOT ok, result is "03/05/2014 01:53:04"
                message.DateTimeStringProperty.ShouldEqual("2014-03-05T01:53:04.193", "Roundtripping DateTimeStringProperty failed"); 

                // NOT ok, result is "03/05/2014 01:53:04"
                message.Dictionary["string-datetime-property"].ShouldEqual("2014-03-05T01:53:04.193", "Roundtripping datetimestring in dictionary failed");  

            }
```

this behavior can be changed by adding `DateParseHandling = DateParseHandling.None` to the serializer settings.
